### PR TITLE
Add support for directly opening archives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+# Configure brace style for C# files
+csharp_new_line_before_open_brace = accessors, blocks, anonymous_methods, control_blocks, events, indexers, methods, object_collection_array_initializers, properties, types

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -21,7 +21,15 @@
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
-        <Button Grid.Column="0" Grid.Row="0" x:Name="btnOpenFolder" Margin="0,5,0,0" Click="ButtonOpenFolder_Click">Open Folder</Button>
+        <Grid Grid.Column="0" Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            
+            <Button Grid.Column="0" Grid.Row="0" x:Name="btnOpenFolder" Margin="0,5,0,0" Click="ButtonOpenFolder_Click">Open Folder</Button>
+            <Button Grid.Column="1" Grid.Row="0" x:Name="btnOpenArchive" Margin="0,5,0,0" Click="ButtonOpenArchive_Click">Open Archive</Button>
+        </Grid>
 
         <Label Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="0" Name="folderLabel">
             No folder selected            

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,16 +1,9 @@
-﻿using System.Text;
+﻿using Microsoft.Win32;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.IO.Compression;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using Microsoft.Win32;
-using System.IO;
-using System.Collections.ObjectModel;
 
 namespace GradescopeIOViewer
 {
@@ -58,6 +51,31 @@ namespace GradescopeIOViewer
             {
                 root = openFolderDialog.FolderName;
 
+                UpdateData();
+            }
+        }
+
+        private void ButtonOpenArchive_Click(object sender, RoutedEventArgs e)
+        {
+            OpenFileDialog openFileDialogue = new OpenFileDialog()
+            {
+                Filter = "Zip Archives (*.zip)|*.zip"
+            };
+            bool? result = openFileDialogue.ShowDialog();
+
+            if (result == true)
+            {
+                string tempPath = Path.GetTempPath() + "\\LsGradescopeIOViewer";
+                if (Directory.Exists(tempPath)) Directory.Delete(tempPath, true);
+
+                ZipFile.ExtractToDirectory(openFileDialogue.FileName, tempPath);
+
+                if (!Directory.Exists(tempPath + "\\Inputs") && Directory.GetDirectories(tempPath).Count() == 1)
+                {
+                    tempPath = Directory.GetDirectories(tempPath).First();
+                }
+
+                root = tempPath;
                 UpdateData();
             }
         }
@@ -112,6 +130,17 @@ namespace GradescopeIOViewer
             this.Title = windowTitle;
 
             folderLabel.Content = $"Folder: \"{root}\"";
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+
+            try
+            {
+                string tempPath = Path.GetTempPath() + "\\LsGradescopeIOViewer";
+                if (Directory.Exists(tempPath)) Directory.Delete(tempPath, true);
+            } catch { }
         }
     }
 }


### PR DESCRIPTION
Added a new `Open Archive` button so users don't need to manually extract the downloaded input/output refs.

<img width="251" height="47" alt="image" src="https://github.com/user-attachments/assets/b310bd2f-fd73-46a1-85bb-cb334f1534f6" />
