### PR TITLE
Added support for opening archives with multiple projects (i.e. weekly tutorials)

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -63,9 +63,7 @@ namespace GradescopeIOViewer
 
             if (result == true)
             {
-                openedPath = openFolderDialog.FolderName;
-                roots = [openFolderDialog.FolderName];
-                UpdateData();
+                LoadFolder(openFolderDialog.FolderName, openFolderDialog.FolderName, "folder");
             }
         }
 
@@ -84,20 +82,25 @@ namespace GradescopeIOViewer
 
                 ZipFile.ExtractToDirectory(openFileDialogue.FileName, tempPath);
 
-                List<string> validDirectories = (new string[] { tempPath }.Concat(Directory.GetDirectories(tempPath)))
+                LoadFolder(tempPath, openFileDialogue.FileName, "archive");
+            }
+        }
+
+        private void LoadFolder(string path, string name, string type)
+        {
+            List<string> validDirectories = (new string[] { path }.Concat(Directory.GetDirectories(path)))
                     .Where(dir => Directory.Exists(dir + "\\Inputs") && Directory.Exists(dir + "\\RefOutputs"))
                     .ToList();
-                if (validDirectories.Count == 0)
-                {
-                    MessageBox.Show("The selected archive does not contain any valid tasks.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                    return;
-                }
-
-                roots = validDirectories.ToArray();
-                rootsShown = Enumerable.Repeat(false, roots.Length).ToArray();
-                openedPath = openFileDialogue.FileName;
-                UpdateData();
+            if (validDirectories.Count == 0)
+            {
+                MessageBox.Show($"The selected {type} does not contain any valid test cases.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
             }
+
+            roots = validDirectories.ToArray();
+            rootsShown = Enumerable.Repeat(false, roots.Length).ToArray();
+            openedPath = name;
+            UpdateData();
         }
 
         private void UpdateData()


### PR DESCRIPTION
This PR adds support for loading zips / folders that have multiple "projects" inside - for example, if you download the `Tutorial 1 - Input and Output.zip` from Canvas, you can now just open that up.

<img width="249" height="378" alt="image" src="https://github.com/user-attachments/assets/39a4862a-56ff-4936-bade-e45c472dbd7d" />

I didn't have to change much, just:
- When opening a folder, look inside that folder for any valid "projects" as well
- Store a list of folders instead of 1, and load all of them in order
- If more than 1 folder is loaded, add headings

Git diff says I changed a lot more than I did because some indenting changed and I moved some duplicate code from archives / folders into one method.

I also realise there's probably a better way of doing this / general room for improvement, so feel free to suggest changes.  `Allow edits by maintainers` is also on so you're welcome to change whatever you want